### PR TITLE
Feature request: Add color support for macOS

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -44,7 +44,7 @@ func New() (l *Logger) {
 		D: log.New(os.Stdout, "[debug]\t", log.Ltime|log.Lshortfile),
 		I: log.New(os.Stdout, "[info]\t", log.Ldate|log.Ltime),
 		W: log.New(os.Stdout, "[warn]\t", log.Ldate|log.Ltime),
-		E: log.New(os.Stdout, "[error]\t", log.Ldate|log.Ltime|log.Lshortfile),
+		E: log.New(os.Stderr, "[error]\t", log.Ldate|log.Ltime|log.Lshortfile),
 		t: true,
 		d: true,
 		i: true,

--- a/logger.go
+++ b/logger.go
@@ -51,7 +51,7 @@ func New() (l *Logger) {
 		w: true,
 		e: true,
 	}
-	if runtime.GOOS == "linux" {
+	if ( runtime.GOOS == "linux" || runtime.GOOS == "darwin" ) {
 		l.T.SetPrefix(blue + l.T.Prefix() + end)
 		l.D.SetPrefix(cyan + l.D.Prefix() + end)
 		l.I.SetPrefix(white + l.I.Prefix() + end)


### PR DESCRIPTION
The macOS terminal supports color output by default also so I thought I'd add support for that to your logger (that's what I run). Also, swapped stdout for stderr as I believe that's more of the convention for logging errors. Though, if you don't want to add that change I can create a PR just with only adding the macOS color support.