### PR TITLE
Feature: Add support for javascript console logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+
+.idea/

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Simplistic, opinionated logging for Golang
 - Simple API
 - Colors on Linux (Windows colors are horrible and unnessecary)
 - Set leveling via environmental variables `LOGGER=trace|debug|info|warn|error`
+- Support for javascript console logging
 
 ```
 [trace] 20:04:57.670116 logger.go:125: trace shows granular timestamp and line info

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # logger
 
-<img src="https://img.shields.io/badge/coverage-83%25-brightgreen.svg?style=flat-square" alt="Code coverage">&nbsp;<a href="https://travis-ci.org/schollz/logger"><img src="https://img.shields.io/travis/schollz/logger.svg?style=flat-square" alt="Build Status"></a>&nbsp;<a href="https://godoc.org/github.com/schollz/logger"><img src="http://img.shields.io/badge/godoc-reference-5272B4.svg?style=flat-square" alt="Go Doc"></a> 
+<img src="https://img.shields.io/badge/coverage-83%25-brightgreen.svg?style=flat-square" alt="Code coverage">
+&nbsp;<a href="https://travis-ci.org/schollz/logger"><img src="https://img.shields.io/travis/schollz/logger.svg?style=flat-square" alt="Build Status"></a>
+&nbsp;<a href="https://godoc.org/github.com/schollz/logger"><img src="http://img.shields.io/badge/godoc-reference-5272B4.svg?style=flat-square" alt="Go Doc"></a>
 
 Simplistic, opinionated logging for Golang
 
@@ -26,8 +28,7 @@ Simplistic, opinionated logging for Golang
 go get github.com/schollz/logger
 ```
 
-## Usage 
-
+## Usage
 
 ```golang
 package main

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/bytedisciple/logger
+module github.com/schollz/logger
 
 go 1.15

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/schollz/logger
+module github.com/bytedisciple/logger
 
-go 1.12
+go 1.15

--- a/logger.go
+++ b/logger.go
@@ -35,29 +35,29 @@ func init() {
 }
 
 type Logger struct {
-	T, D, I, W, E *log.Logger
-	t, d, i, w, e bool
+	TraceLogger, DebugLogger, InfoLogger, WarnLogger, ErrorLogger     *log.Logger
+	traceEnabled, debugEnable, infoEnabled, warnEnabled, errorEnabled bool
 }
 
 func New() (l *Logger) {
 	l = &Logger{
-		T: log.New(os.Stdout, "[trace]\t", log.Ltime|log.Lmicroseconds|log.Lshortfile),
-		D: log.New(os.Stdout, "[debug]\t", log.Ltime|log.Lshortfile),
-		I: log.New(os.Stdout, "[info]\t", log.Ldate|log.Ltime),
-		W: log.New(os.Stdout, "[warn]\t", log.Ldate|log.Ltime),
-		E: log.New(os.Stdout, "[error]\t", log.Ldate|log.Ltime|log.Lshortfile),
-		t: true,
-		d: true,
-		i: true,
-		w: true,
-		e: true,
+		TraceLogger: log.New(os.Stdout, "[trace]\t", log.Ltime|log.Lmicroseconds|log.Lshortfile),
+		DebugLogger: log.New(os.Stdout, "[debug]\t", log.Ltime|log.Lshortfile),
+		InfoLogger:  log.New(os.Stdout, "[info]\t", log.Ldate|log.Ltime),
+		WarnLogger:  log.New(os.Stdout, "[warn]\t", log.Ldate|log.Ltime),
+		ErrorLogger: log.New(os.Stdout, "[error]\t", log.Ldate|log.Ltime|log.Lshortfile),
+		traceEnabled: true,
+		debugEnable:  true,
+		infoEnabled:  true,
+		warnEnabled:  true,
+		errorEnabled: true,
 	}
 	if runtime.GOOS == "linux" {
-		l.T.SetPrefix(blue + l.T.Prefix() + end)
-		l.D.SetPrefix(cyan + l.D.Prefix() + end)
-		l.I.SetPrefix(white + l.I.Prefix() + end)
-		l.W.SetPrefix(yellow + l.W.Prefix() + end)
-		l.E.SetPrefix(red + l.E.Prefix() + end)
+		l.TraceLogger.SetPrefix(blue + l.TraceLogger.Prefix() + end)
+		l.DebugLogger.SetPrefix(cyan + l.DebugLogger.Prefix() + end)
+		l.InfoLogger.SetPrefix(white + l.InfoLogger.Prefix() + end)
+		l.WarnLogger.SetPrefix(yellow + l.WarnLogger.Prefix() + end)
+		l.ErrorLogger.SetPrefix(red + l.ErrorLogger.Prefix() + end)
 	}
 	if strings.TrimSpace(strings.ToLower(os.Getenv("LOGGER"))) != "" {
 		l.SetLevel(strings.TrimSpace(strings.ToLower(os.Getenv("LOGGER"))))
@@ -78,34 +78,34 @@ func SetLevel(s string) {
 }
 
 func (l *Logger) SetOutput(w io.Writer) {
-	l.T.SetOutput(w)
-	l.D.SetOutput(w)
-	l.I.SetOutput(w)
-	l.W.SetOutput(w)
-	l.E.SetOutput(w)
+	l.TraceLogger.SetOutput(w)
+	l.DebugLogger.SetOutput(w)
+	l.InfoLogger.SetOutput(w)
+	l.WarnLogger.SetOutput(w)
+	l.ErrorLogger.SetOutput(w)
 }
 
 func (l *Logger) SetLevel(s string) {
-	l.t = true
-	l.d = true
-	l.i = true
-	l.w = true
-	l.e = true
+	l.traceEnabled = true
+	l.debugEnable = true
+	l.infoEnabled = true
+	l.warnEnabled = true
+	l.errorEnabled = true
 	switch s {
 	case "debug":
-		l.t = false
+		l.traceEnabled = false
 	case "info":
-		l.t = false
-		l.d = false
+		l.traceEnabled = false
+		l.debugEnable = false
 	case "warn":
-		l.t = false
-		l.d = false
-		l.i = false
+		l.traceEnabled = false
+		l.debugEnable = false
+		l.infoEnabled = false
 	case "error":
-		l.t = false
-		l.d = false
-		l.i = false
-		l.w = false
+		l.traceEnabled = false
+		l.debugEnable = false
+		l.infoEnabled = false
+		l.warnEnabled = false
 	}
 }
 
@@ -114,13 +114,13 @@ func GetLevel() (s string) {
 }
 
 func (l *Logger) GetLevel() (s string) {
-	if l.t {
+	if l.traceEnabled {
 		return "trace"
-	} else if l.d {
+	} else if l.debugEnable {
 		return "debug"
-	} else if l.i {
+	} else if l.infoEnabled {
 		return "info"
-	} else if l.w {
+	} else if l.warnEnabled {
 		return "warn"
 	}
 	return "error"
@@ -152,46 +152,19 @@ func Trace(v ...interface{}) {
 
 func Debug(v ...interface{}) {
 	l.Debugf(fmt.Sprint(v...))
+
 }
 
 func Info(v ...interface{}) {
 	l.Infof(fmt.Sprint(v...))
+
 }
 
 func Warn(v ...interface{}) {
 	l.Warnf(fmt.Sprint(v...))
+
 }
 
 func Error(v ...interface{}) {
 	l.Errorf(fmt.Sprint(v...))
-}
-
-func (l *Logger) Tracef(format string, v ...interface{}) {
-	if l.t {
-		l.T.Output(3, fmt.Sprintf(format, v...))
-	}
-}
-
-func (l *Logger) Debugf(format string, v ...interface{}) {
-	if l.d {
-		l.D.Output(3, fmt.Sprintf(format, v...))
-	}
-}
-
-func (l *Logger) Infof(format string, v ...interface{}) {
-	if l.i {
-		l.I.Output(3, fmt.Sprintf(format, v...))
-	}
-}
-
-func (l *Logger) Warnf(format string, v ...interface{}) {
-	if l.w {
-		l.W.Output(3, fmt.Sprintf(format, v...))
-	}
-}
-
-func (l *Logger) Errorf(format string, v ...interface{}) {
-	if l.e {
-		l.E.Output(3, fmt.Sprintf(format, v...))
-	}
 }

--- a/logger.go
+++ b/logger.go
@@ -152,17 +152,14 @@ func Trace(v ...interface{}) {
 
 func Debug(v ...interface{}) {
 	l.Debugf(fmt.Sprint(v...))
-
 }
 
 func Info(v ...interface{}) {
 	l.Infof(fmt.Sprint(v...))
-
 }
 
 func Warn(v ...interface{}) {
 	l.Warnf(fmt.Sprint(v...))
-
 }
 
 func Error(v ...interface{}) {

--- a/logger_js.go
+++ b/logger_js.go
@@ -1,0 +1,38 @@
+//+build js
+
+package logger
+
+import (
+	"fmt"
+	"syscall/js"
+)
+
+func (l *Logger) Tracef(format string, v ...interface{}) {
+	if l.traceEnabled {
+		js.Global().Get("console").Call("trace", fmt.Sprintf(format, v...))
+	}
+}
+
+func (l *Logger) Debugf(format string, v ...interface{}) {
+	if l.debugEnable {
+		js.Global().Get("console").Call("debug", fmt.Sprintf(format, v...))
+	}
+}
+
+func (l *Logger) Infof(format string, v ...interface{}) {
+	if l.infoEnabled {
+		js.Global().Get("console").Call("info", fmt.Sprintf(format, v...))
+	}
+}
+
+func (l *Logger) Warnf(format string, v ...interface{}) {
+	if l.warnEnabled {
+		js.Global().Get("console").Call("warn", fmt.Sprintf(format, v...))
+	}
+}
+
+func (l *Logger) Errorf(format string, v ...interface{}) {
+	if l.errorEnabled {
+		js.Global().Get("console").Call("error", fmt.Sprintf(format, v...))
+	}
+}

--- a/logger_other.go
+++ b/logger_other.go
@@ -1,0 +1,35 @@
+// +build !js
+
+package logger
+
+import "fmt"
+
+func (l *Logger) Tracef(format string, v ...interface{}) {
+	if l.traceEnabled {
+		l.TraceLogger.Output(3, fmt.Sprintf(format, v...))
+	}
+}
+
+func (l *Logger) Debugf(format string, v ...interface{}) {
+	if l.debugEnable {
+		l.DebugLogger.Output(3, fmt.Sprintf(format, v...))
+	}
+}
+
+func (l *Logger) Infof(format string, v ...interface{}) {
+	if l.infoEnabled {
+		l.InfoLogger.Output(3, fmt.Sprintf(format, v...))
+	}
+}
+
+func (l *Logger) Warnf(format string, v ...interface{}) {
+	if l.warnEnabled {
+		l.WarnLogger.Output(3, fmt.Sprintf(format, v...))
+	}
+}
+
+func (l *Logger) Errorf(format string, v ...interface{}) {
+	if l.errorEnabled {
+		l.ErrorLogger.Output(3, fmt.Sprintf(format, v...))
+	}
+}


### PR DESCRIPTION
This library now supports JS compilation target. 

Previously, all logs would be suppressed if the compilation target was JS. The changes introduced in `logger_js.go` and `logger_other.go` enable the logs to be redirected to the javascript console if running in the browser.

I also renamed many of the 1 letter variables for clarity and bumped the go version to 1.15 as it has more extensive support for js compilation.